### PR TITLE
Add ability to choose which watermark to use on images

### DIFF
--- a/simplicity-gallery-v1.lrwebengine/galleryInfo.lrweb
+++ b/simplicity-gallery-v1.lrwebengine/galleryInfo.lrweb
@@ -47,6 +47,7 @@ return {
 
 		["lightroomApplication.jpegQuality"] = 80,
 		["lightroomApplication.useWatermark"] = true,
+		["lightroomApplication.watermarkID"] = "",
 		["lightroomApplication.identityPlateExport"] = "(main)",
 
 		["photoSizes.thumb.height"] = 2000, 
@@ -202,13 +203,8 @@ return {
 									precision = 0,
 									},
 							},
-				
-							f:header_section {
-								f:checkbox_row {
-									title = "Copyright Watermark",
-									value = bind "lightroomApplication.useWatermark",
-									},
-							},
+
+							f:watermark_section( controller ),
 						},
 				},				
 			}


### PR DESCRIPTION
Use default watermarking function instead of custom definition to have
ability to choose which exactly watermark to use instead of using the
latest one by default in Lightroom API.

Signed-off-by: Igor Shishkin <me@teran.ru>