### PR TITLE
Fix for explicit HTTP scheme usage on accessing Google Fonts service

### DIFF
--- a/simplicity-gallery-v1.lrwebengine/resources/styles/bootstrap.min.css
+++ b/simplicity-gallery-v1.lrwebengine/resources/styles/bootstrap.min.css
@@ -1,4 +1,4 @@
-@import url("http://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700");/*!
+@import url("//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,700italic,400,300,700");/*!
  * bootswatch v3.3.1+1
  * Homepage: http://bootswatch.com
  * Copyright 2012-2014 Thomas Park


### PR DESCRIPTION
In some cases like placing the gallery on HTTPS server it wont work
with current fonts.google.com access way. So setting it to '//' to make
it use the same scheme as for site access.

Signed-off-by: Igor Shishkin <me@teran.ru>